### PR TITLE
Limit characters on PTS sidebar inputs

### DIFF
--- a/public/stylesheets/overlays/pardonthesmash/overlay.css
+++ b/public/stylesheets/overlays/pardonthesmash/overlay.css
@@ -91,6 +91,11 @@ a {
 	color: white;
 }
 
+#topic-container {
+	overflow: hidden;
+	white-space: nowrap;
+}
+
 #topic-header {
 	background-color: white;
 	padding: 0px 10px;

--- a/views/overlays/pardonthesmash/admin.hbs
+++ b/views/overlays/pardonthesmash/admin.hbs
@@ -28,7 +28,7 @@
 		</thead>
 		<tbody id="topic-table-body">
 			<tr>
-				<td><input class="sidebar" /></td>
+				<td><input class="sidebar" maxlength="15" /></td>
 				<td><input class="mainbar" maxlength="38" /></td>
 				<td><input type="radio" class="active" name="active" checked /></td>
 			</tr>


### PR DESCRIPTION
Limit the number of characters on the PTS sidebar text inputs to 15. Also, make the PTS background transparent so it's easier to use as an overlay.
