### PR TITLE
Add a second to the timer input values

### DIFF
--- a/views/overlays/pardonthesmash/admin.hbs
+++ b/views/overlays/pardonthesmash/admin.hbs
@@ -95,8 +95,12 @@
 
 	function sendTimerUpdate(minutes, seconds) {
 		var date = new Date();
+		// TODO: Figure out what calculation causes seconds to need a plus one.
+		// Without the plus one, entering in 3 minutes will start the timer
+		// showing 2:59, and it'll sit there for a bit longer than a second before
+		// it starts ticking.
 		date.setMinutes(date.getMinutes() + minutes);
-		date.setSeconds(date.getSeconds() + seconds);
+		date.setSeconds(date.getSeconds() + seconds + 1);
 
 		var data = {
 			'endTime': date.toISOString(),


### PR DESCRIPTION
When 3 minutes is entered, timer is expected to start at 3:00. Probably a millisecond calculation issue. For the first second, the timer appears to tick longer than a second. For now, this is acceptable behavior, but would be a good quality of life improvement later.
