### PR TITLE
Update packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,16 +6,16 @@
     "start": "node ./bin/www"
   },
   "dependencies": {
-    "body-parser": "~1.8.1",
-    "cookie-parser": "~1.3.3",
-    "debug": "~2.0.0",
-    "express": "~4.9.0",
-    "hbs": "~2.7.0",
-    "morgan": "~1.3.0",
+    "body-parser": "~1.12.2",
+    "cookie-parser": "~1.3.4",
+    "debug": "~2.1.3",
+    "express": "~4.12.3",
+    "hbs": "~3.0.1",
+    "morgan": "~1.5.2",
     "redis": "^0.12.1",
-    "request": "^2.51.0",
-    "serve-favicon": "~2.1.3",
-    "socket.io": "^1.2.1",
+    "request": "^2.55.0",
+    "serve-favicon": "~2.2.0",
+    "socket.io": "1.3.1",
     "socket.io-redis": "^0.1.4"
   }
 }


### PR DESCRIPTION
socket.io has a bug in the latest release (https://github.com/Automattic/socket.io-client/issues/812), so needed to specify a package more explicitly. I took the opportunity to update all of our packages.