### PR TITLE
Fix a casing issue with match intro routes

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -102,7 +102,7 @@ router.get('/overlays/bracket', function(req, res) {
 
 /* GET matchIntro page. */
 router.get('/overlays/matchIntro', function(req, res) {
-  res.render('overlays/MatchIntro', { title: 'Match Introduction Screen', layout: false });
+  res.render('overlays/matchIntro', { title: 'Match Introduction Screen', layout: false });
 });
 
 


### PR DESCRIPTION
Mac and Windows have case-insensitive file systems, but Linux has a case-sensitive file system, so this view wasn't getting picked up.