### PR TITLE
Add try/catch to Challonge parsing.

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ var favicon = require('serve-favicon');
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
+var pmx = require('pmx');
 
 var routes = require('./routes/index');
 
@@ -62,5 +63,7 @@ app.use(function(err, req, res, next) {
     });
 });
 
+// attach more data from express errors:
+app.use(pmx.expressErrorHandler());
 
 module.exports = app;

--- a/sockets/challonge.js
+++ b/sockets/challonge.js
@@ -1,6 +1,7 @@
 var config = require('../config');
 var request = require('request');
 var redis = require('redis');
+var pmx = require('pmx');
 
 var client = redis.createClient();
 var redisKey = 'web-overlay-challonge';
@@ -102,10 +103,16 @@ module.exports = function(io) {
             request(options, function (error, response, body) {
                 console.log('Challonge Response: ' + response.statusCode);
                 if (!error && response.statusCode === 200) {
-                    var challongeResponse = JSON.parse(body);
-                    matches = challongeResponse.tournament.matches;
-                    players = challongeResponse.tournament.participants;
-                    sendChallongeUpdate();
+                    try {
+                        var challongeResponse = JSON.parse(body);
+                        matches = challongeResponse.tournament.matches;
+                        players = challongeResponse.tournament.participants;
+                        sendChallongeUpdate();
+                    } catch (e) {
+                        var errorMessage = 'Challonge response could not be parsed: ' + body;
+                        console.log(errorMessage);
+                        pmx.notify(errorMessage);
+                    }
                 }
             });
         }


### PR DESCRIPTION
I've seen the occasional exception from parsing Challonge JSON, even though Challonge returns 200. This branch adds a try/catch to stop the error from happening, and hopefully log the body of the message that's causing the exception.

Fixes #107 