### PR TITLE
Ignore settings folder in VS Code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 Thumbs.db
 config.js*
 .node-xmlhttprequest-sync-*
+.settings


### PR DESCRIPTION
Visual Studio Code stores settings in a folder called `.settings`. That folder should be ignored.