### PR TITLE
Pull in some newer packages from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,16 +6,16 @@
     "start": "node ./bin/www"
   },
   "dependencies": {
-    "body-parser": "~1.12.2",
-    "cookie-parser": "~1.3.4",
-    "debug": "~2.1.3",
-    "express": "~4.12.3",
-    "hbs": "~3.0.1",
-    "morgan": "~1.5.2",
-    "pmx": "^0.3.5",
+    "body-parser": "~1.13.3",
+    "cookie-parser": "~1.3.5",
+    "debug": "~2.2.0",
+    "express": "~4.13.3",
+    "hbs": "~3.1.0",
+    "morgan": "~1.6.1",
+    "pmx": "^0.3.28",
     "redis": "^0.12.1",
-    "request": "^2.55.0",
-    "serve-favicon": "~2.2.0",
+    "request": "^2.60.0",
+    "serve-favicon": "~2.3.0",
     "socket.io": "1.3.1",
     "socket.io-redis": "^0.1.4"
   }


### PR DESCRIPTION
I'm not sure that the bug with socket.io routes has been fixed yet, so I didn't bother updating it, but everything else is now at latest.