### PR TITLE
Update commentators view to support twitter handles and names

### DIFF
--- a/public/javascripts/overlays/admin.js
+++ b/public/javascripts/overlays/admin.js
@@ -153,7 +153,9 @@ socket.on('update overlay', function(data) {
     document.getElementById('title').value = data.title || '';
     document.getElementById('tourneyInfo').value = data.tourneyInfo || '';
     document.getElementById('commentators').value = data.commentators || '';
+    document.getElementById('commentators2').value = data.commentators2 || '';
     document.getElementById('twitter').value = data.twitter || '';
+    document.getElementById('twitter2').value = data.twitter2 || '';
     document.getElementById('current-game').value = data.currentGame || '';
     document.getElementById('lscore').value = data.lscore || 0;
     document.getElementById('rscore').value = data.rscore || 0;
@@ -359,7 +361,9 @@ function sendUpdate(infoMessage) {
         'lscore': document.getElementById('lscore').value,
         'rscore': document.getElementById('rscore').value,
         'commentators': document.getElementById('commentators').value,
+        'commentators2': document.getElementById('commentators2').value,
         'twitter': document.getElementById('twitter').value,
+        'twitter2': document.getElementById('twitter2').value,
         'currentGame': document.getElementById('current-game').value,
         'lCharacter': window.characterLeft || null,
         'rCharacter': window.characterRight || null,

--- a/public/stylesheets/overlays/commentators.css
+++ b/public/stylesheets/overlays/commentators.css
@@ -9,24 +9,68 @@ a {
 #container {
 	width: 1920px;
 	height: 1080px;
-	background: url(https://i.imgur.com/VeDdEp2.png);
+	background: url(http://i.imgur.com/LlPja7O.png);
 	position: relative;
 }
 
-.playertext {
-	position: absolute;
+.twitter-icon {
+    width: 48px;
+    height: 48px;
+    background: url(http://i.imgur.com/RGl4CvZ.png);
+    display: inline-block;
+    vertical-align: text-top;
+    margin-right: -10px;
+}
+
+.playertext {	
 	color: white;
-	font-size: 42px;
 	font-family: Arial, sans-serif;
 	overflow: hidden;
 	overflow-wrap: break-word;
 }
 
 #commentators {
-	top: 933px;
-	left: 500px;
-	height: 83px;
-	width: 880px;
+	top: 850px;
+	left: 100px;
+	height: 50px;
+	width: 800px;
 	text-align: center;
 	font-size: 48px;
+    position: absolute;
+}
+
+#twittercontainer {
+	top: 963px;
+	left: 84px;
+	height: 50px;
+	width: 800px;
+	text-align: center;
+	font-size: 36px;
+    position: absolute;
+}
+
+.twitter{
+    display: inline-block;
+    vertical-align: text-top;
+}
+
+#twittercontainer2 {
+	top: 963px;
+	right: 112px;
+	height: 50px;
+	width: 800px;
+	text-align: center;
+	font-size: 36px;
+    position: absolute;
+}
+
+
+#commentators2 {
+	top: 850px;
+	right: 100px;
+	height: 50px;
+	width: 800px;
+	text-align: center;
+	font-size: 48px;
+    position: absolute;
 }

--- a/views/overlays/admin.hbs
+++ b/views/overlays/admin.hbs
@@ -30,13 +30,23 @@
                 </p>
                 <p>
                     <label for="commentators">
-                        Commentators
+                        L Commentator
                         <input id="commentators"></input>
+                    </label>
+                    
+                    <label for="commentators2">
+                        R Commentator
+                        <input id="commentators2"></input>
                     </label>
 
                     <label for="twitter">
-                        Twitter Handles
+                        L Twitter
                         <input id="twitter"></input>
+                    </label>
+                    
+                    <label for="twitter2">
+                        R Twitter
+                        <input id="twitter2"></input>
                     </label>
                     
                     <label for="current-game">

--- a/views/overlays/commentators.hbs
+++ b/views/overlays/commentators.hbs
@@ -11,16 +11,38 @@
   <body>
   	<div id="container">
   		<div id="commentators" class="playertext"></div>
+          
+          <div id="twittercontainer">
+              <img src="http://i.imgur.com/RGl4CvZ.png" class="twitter-icon">
+              <div id="twitter" class="twitter playertext"></div>
+          </div>
+          
+          <div id="commentators2" class="playertext"></div>
+          
+          <div id="twittercontainer2">
+              <img src="http://i.imgur.com/RGl4CvZ.png" class="twitter-icon">
+              <div id="twitter2" class="twitter playertext"></div>
+          </div>
   	</div>
     <script>
     var processedFollowers = [];
-		var socket = io('/overlay');
+    var socket = io('/overlay');
 
-		socket.on('update overlay', function(data) {
-      if(data.commentators != document.getElementById('commentators').innerText) {
+    socket.on('update overlay', function(data) {
+        if(data.commentators != document.getElementById('commentators').innerText) {
           $('#commentators').trigger('textChanged', data.commentators || '');
         }
-		});
+        if(data.commentators2 != document.getElementById('commentators2').innerText) {
+          $('#commentators2').trigger('textChanged', data.commentators2 || '');
+        }
+        if(data.twitter != document.getElementById('twitter').innerText) {
+          $('#twitter').trigger('textChanged', data.twitter || '');
+        }
+        if(data.twitter2 != document.getElementById('twitter2').innerText) {
+          $('#twitter2').trigger('textChanged', data.twitter2 || '');
+        }
+    });
+        
 
     $('.playertext').bind('textChanged', function(e, newText){
         $(this).animate({'opacity': '0', 'margin-left': '-1%'}, 350, function() {


### PR DESCRIPTION
Updates the commentators layout to support clearly defined commentators as well as Twitter handles. Here's a quick screenshot (crappy cropping):

<img width="934" alt="screenshot 2016-02-02 16 08 26" src="https://cloud.githubusercontent.com/assets/4380972/12766093/7f7b5870-c9c7-11e5-8629-7879776a124a.png">

Closes https://github.com/The-Velvet-Room/web-overlay/issues/149