### PR TITLE
Fix resetting the port color to None

### DIFF
--- a/public/javascripts/overlays/admin.js
+++ b/public/javascripts/overlays/admin.js
@@ -74,12 +74,12 @@ function createPortList(direction) {
 
     $('#port'+direction).change(function(){
         var selectedOption = $('#port'+direction+' option:selected');
+        var value =  selectedOption.val() == 'null' ? null : selectedOption.val();
 
-        if(direction == 'Left') {
-            portLeft = selectedOption.val();
-        }
-        else {
-            portRight = selectedOption.val();
+        if (direction == 'Left') {
+            portLeft = value
+        } else {
+            portRight = value
         }
         sendUpdate();
     });


### PR DESCRIPTION
Port color couldn't be reset because it was sending a string containing "null" instead of a null value. I'm not sure we'll ever use this feature, but I wanted to clear the bug out of our backlog.

Fixes #124 